### PR TITLE
OT161-75: Método reutilizable que realice una petición POST a los endpoints públicos de la API

### DIFF
--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -4,7 +4,7 @@ const BASE_URL = 'https://ongapi.alkemy.org/api';
 /**
  * Function to generate a POST request
  * @param {string} route  Endpoint's route. Example: "/testimonials"
- * @param {Object} data Object with the post data
+ * @param {Object} postData Object with the post data
  */
 async function publicPostRequest(route, postData) {
 	try {

--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -6,7 +6,7 @@ const BASE_URL = 'https://ongapi.alkemy.org/api';
  * @param {string} route  Endpoint's route. Example: "/testimonials"
  * @param {Object} data Object with the post data
  */
-async function Post(route, postData) {
+async function publicPostRequest(route, postData) {
 	try {
 		const {data} = await axios.post(`${BASE_URL}${route}`, postData);
         return data
@@ -15,4 +15,4 @@ async function Post(route, postData) {
 	}
 }
 
-export { Post };
+export { publicPostRequest };

--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -1,15 +1,18 @@
 import axios from 'axios';
+const BASE_URL = 'https://ongapi.alkemy.org/api';
 
-const config = {
-    headers: {
-        Group: 01                //Aqui va el ID del equipo!!
-    }
+/**
+ * Function to generate a POST request
+ * @param {string} route  Endpoint's route. Example: "/testimonials"
+ * @param {Object} data Object with the post data
+ */
+async function Post(route, postData) {
+	try {
+		const {data} = await axios.post(`${BASE_URL}${route}`, postData);
+        return data
+	} catch (error) {
+		return error
+	}
 }
 
-const Get = () => {
-    axios.get('https://jsonplaceholder.typicode.com/users', config)
-    .then(res => console.log(res))
-    .catch(err => console.log(err))
-}
-
-export default Get
+export { Post };


### PR DESCRIPTION
Método reutilizable que realice una petición POST a los endpoints públicos de la API 