### PR TITLE
fix: delete a path method that should be not there

### DIFF
--- a/src/Services/publicApiService.js
+++ b/src/Services/publicApiService.js
@@ -16,15 +16,6 @@ async function publicPostRequest(route, postData) {
 	}
 }
 
-async function publicPatchRequest(route, patchData) {
-	try {
-		const { data } = await axios.patch(`${BASE_URL}${route}`, patchData);
-		return data;
-	} catch (error) {
-		return error;
-	}
-}
-
 const getDataMethod = async (sector, id = null, data = null) => {
 	if (sector !== 'auth') {
 		try {
@@ -53,4 +44,4 @@ const getDataMethod = async (sector, id = null, data = null) => {
 	}
 };
 
-export { publicPostRequest, publicPatchRequest, getDataMethod };
+export { publicPostRequest, getDataMethod };


### PR DESCRIPTION
**publicService.js**

- Elimina una funcion path publica que no deberia estar y se soluciona el error que tira el compilador al estar usando en la misma funcion la variable BASE_URL que eliminamos al comenzar a usar las variables de entorno