### PR TITLE
@boniich/arregla obj de config borrado

### DIFF
--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ShowTitle from '../../shared/ShowTitle';
-// import Members from './Members';
+import Members from './Members';
 import { getDataMethod } from '../../Services/publicApiService';
 const About = () => {
 	const [showDescription, setShowDescription] = useState('');
@@ -36,7 +36,7 @@ const About = () => {
 			<div>
 				<h1>Miembros</h1>
 				<p>Conoce a los valiosos miembros de nuestra ONG</p>
-				{/* <Members /> */}
+				<Members />
 			</div>
 		</section>
 	);

--- a/src/Components/Dashboard/CardDashboard.js
+++ b/src/Components/Dashboard/CardDashboard.js
@@ -1,37 +1,37 @@
-import React from "react";
-import styles from "./Dashboard.module.css";
-import { useHistory } from "react-router";
-import PropTypes from "prop-types";
+import React from 'react';
+import styles from './Dashboard.module.css';
+import { useHistory } from 'react-router-dom';
+import PropTypes from 'prop-types';
 
 const CardDashboard = ({ title, icon, link }) => {
-  const history = useHistory();
+	const history = useHistory();
 
-  CardDashboard.propTypes = {
-    title: PropTypes.string,
-    icon: PropTypes.string,
-    link: PropTypes.string,
-  };
+	CardDashboard.propTypes = {
+		title: PropTypes.string,
+		icon: PropTypes.string,
+		link: PropTypes.string,
+	};
 
-  const linked = () => {
-    history.push(link);
-  };
+	const linked = () => {
+		history.push(link);
+	};
 
-  return (
-    <div className={styles.containerCard}>
-      <h3 className={styles.title}>{title}</h3>
-      <i
-        className={icon}
-        style={{
-          width: "100px",
-          height: "auto",
-          padding: "10px",
-        }}
-      ></i>
-      <button onClick={linked} className={styles.btn}>
-        Ir
-      </button>
-    </div>
-  );
+	return (
+		<div className={styles.containerCard}>
+			<h3 className={styles.title}>{title}</h3>
+			<i
+				className={icon}
+				style={{
+					width: '100px',
+					height: 'auto',
+					padding: '10px',
+				}}
+			></i>
+			<button onClick={linked} className={styles.btn}>
+				Ir
+			</button>
+		</div>
+	);
 };
 
 export default CardDashboard;

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -5,6 +5,13 @@ const headers = {
 	Autorizacion: tokenFromLocalStorage(),
 };
 
+/**
+ * Function to generate a POST request
+ * @param {string} route  Endpoint's route. Example: "/testimonials"
+ * @param {Object} postData Object with the post data
+ * @returns {Promise}
+ */
+
 export const privatePostRequest = async (route, postData) => {
 	try {
 		const { data } = await axios.post(
@@ -18,6 +25,13 @@ export const privatePostRequest = async (route, postData) => {
 	}
 };
 
+/**
+ * Function to generate a PUT request
+ * @param {string} url  Endpoint's url. Example: "/testimonials"
+ * @param {Object} putData Object with the post data
+ * @returns {Promise}
+ */
+
 export const privatePutRequest = async ({ url, putData }) => {
 	try {
 		const res = await axios.put(
@@ -30,6 +44,13 @@ export const privatePutRequest = async ({ url, putData }) => {
 		console.log(err);
 	}
 };
+
+/**
+ * Function to generate a DELETE request
+ * @param {string} url  Endpoint's url. Example: "/testimonials"
+ * @param {Object} deleteData Object with the post data
+ * @returns {Promise}
+ */
 
 export const privateDeleteRequest = async ({ url }) => {
 	try {
@@ -64,6 +85,13 @@ export async function privatePatchRequest(route, patchData) {
 	}
 }
 
+/**
+ * Function to generate a GET request
+ * @param {string} sector  Endpoint's sector. Example: "/testimonials". Si el valor de "sector" es auth va a realizar una peticion distinta relacionada a la utentificacion
+ * @param {number} id  El id seria un dato en especifico que se quiera devolver. Puede ir null
+ * @returns {Promise}
+ */
+
 const getDataMethodPrivate = async (sector, id = null) => {
 	if (sector !== 'auth') {
 		try {
@@ -82,9 +110,7 @@ const getDataMethodPrivate = async (sector, id = null) => {
 		try {
 			const result = await axios.get(
 				`${process.env.REACT_APP_BASE_URL}/auth/me`,
-				{
-					headers,
-				}
+				headers
 			);
 			console.log(result);
 			return result;

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,7 +1,11 @@
 import axios from 'axios';
 
+const headers = {
+	Group: 161,
+	Autorizacion: tokenFromLocalStorage(),
+};
+
 export const privatePostRequest = async (route, postData) => {
-	const headers = { ...tokenFromLocalStorage() };
 	try {
 		const { data } = await axios.post(
 			`${process.env.REACT_APP_BASE_URL}/${route}`,
@@ -15,7 +19,6 @@ export const privatePostRequest = async (route, postData) => {
 };
 
 export const privatePutRequest = async ({ url, putData }) => {
-	const headers = { ...tokenFromLocalStorage() };
 	try {
 		const res = await axios.put(
 			`${process.env.REACT_APP_BASE_URL}/${url}`,
@@ -29,7 +32,6 @@ export const privatePutRequest = async ({ url, putData }) => {
 };
 
 export const privateDeleteRequest = async ({ url }) => {
-	const headers = { ...tokenFromLocalStorage() };
 	try {
 		const res = await axios.delete(
 			`${process.env.REACT_APP_BASE_URL}/${url}`,
@@ -63,7 +65,6 @@ export async function privatePatchRequest(route, patchData) {
 }
 
 const getDataMethodPrivate = async (sector, id = null) => {
-	const headers = { ...tokenFromLocalStorage() };
 	if (sector !== 'auth') {
 		try {
 			const result = await axios.get(
@@ -96,16 +97,10 @@ const getDataMethodPrivate = async (sector, id = null) => {
 export default getDataMethodPrivate;
 
 function tokenFromLocalStorage() {
-	const noTokenValue = {
-		undefined: undefined,
-		null: null,
-	};
 	const token = window.localStorage.getItem('token');
-	if (!token || !noTokenValue[token]) {
+	if (!token || token === 'undefined') {
 		console.log('No token in local storage');
 		return null;
 	}
-	return {
-		Authorization: `Bearer ${token}`,
-	};
+	return `Bearer ${token}`;
 }


### PR DESCRIPTION
**privateApiService.j**

- Se vuelve a agregar la propiedad del grupo que fue sacada hace unas semanas. Se agrega dentro del obj `headers`
- Se dejo un solo objeto `headers` en forma global dentro del archivo. No se modifico la forma en que las funciones lo reciben
- Se modifico la funcion `tokenFromLocalStorage()` ya que tenia un problema que hacia que ningun token fuera valido
- Se agrego algo de documentacion JSDoc.
- Se soluciono que la parte de la función get que maneja el endpoint de `auth` recibiera el objeto `headers` como una propiedad.

**CardDashBoard**

- Se soluciono un import de `react rute` que estaba mal segun parece y daba fallos de compilación

**About.js**

- Se descomenta un componente que renderiza los miembros de la ong