### PR TITLE
@boniich/task/msg error en servicio de testimonio

### DIFF
--- a/src/Services/testimonialService.js
+++ b/src/Services/testimonialService.js
@@ -1,3 +1,5 @@
+// import showAlert from '../shared/showAlert';
+import showAlert from '../shared/showAlert';
 import getDataMethodPrivate, {
 	privatePatchRequest,
 	privateDeleteRequest,
@@ -8,6 +10,9 @@ export async function getAllTestimonials() {
 		const { data } = await getDataMethodPrivate(
 			process.env.REACT_APP_TESTIMONIAL_END_POINT
 		);
+		// Maneja el error y la alerta. La funcion se encuentra abajo de todo
+		handlError(data, 'No se pudieron mostrar los testimonios');
+
 		return data;
 	} catch (error) {
 		return error;
@@ -20,9 +25,13 @@ export async function createTestimonial(contactData) {
 			process.env.REACT_APP_TESTIMONIAL_END_POINT,
 			contactData
 		);
+
+		handlError(data, 'Lo sentimos, no fue posible cargar los testimonios');
+
 		return data;
-	} catch (error) {
-		return error;
+	} catch (err) {
+		// este catch no funciona
+		console.log(err);
 	}
 }
 export async function getTestimonialById(id) {
@@ -31,6 +40,9 @@ export async function getTestimonialById(id) {
 			process.env.REACT_APP_TESTIMONIAL_END_POINT,
 			id
 		);
+
+		handlError(data, 'Lo sentimos, no fue posible mostrar los resultados');
+
 		return data;
 	} catch (error) {
 		return error;
@@ -42,6 +54,9 @@ export async function updateTestimonial(id, contactData) {
 			`${process.env.REACT_APP_TESTIMONIAL_END_POINT}/${id}`,
 			contactData
 		);
+
+		handlError(data, 'Lo sentimos, no fue posible actualizar los testimonios');
+
 		return data;
 	} catch (error) {
 		return error;
@@ -53,8 +68,26 @@ export async function deleteTestimonial(id) {
 		const { data } = await privateDeleteRequest({
 			url: `${process.env.REACT_APP_TESTIMONIAL_END_POINT}/${id}`,
 		});
+
+		handlError(data, 'Lo sentimos, no fue posible eliminar el testimonio');
+
 		return data;
 	} catch (error) {
 		return error;
 	}
 }
+
+// esta funcion maneja y muestra el error por si la peticion falla
+// Solo se ejecuta si la condicion interna es verdadera
+
+const handlError = (data, message) => {
+	// se utiliza la propiedad "success" que devuelve el back par comprar si la peticion falla
+	if (data.success !== true) {
+		console.log('el Error se muestra Exitosamente');
+		showAlert({
+			type: 'error',
+			title: 'Ups. Hubo un error.',
+			message: message,
+		});
+	}
+};

--- a/src/Services/testimonialService.js
+++ b/src/Services/testimonialService.js
@@ -1,4 +1,3 @@
-// import showAlert from '../shared/showAlert';
 import showAlert from '../shared/showAlert';
 import getDataMethodPrivate, {
 	privatePatchRequest,

--- a/src/Services/testimonialService.js
+++ b/src/Services/testimonialService.js
@@ -11,7 +11,7 @@ export async function getAllTestimonials() {
 			process.env.REACT_APP_TESTIMONIAL_END_POINT
 		);
 		// Maneja el error y la alerta. La funcion se encuentra abajo de todo
-		handlError(data, 'No se pudieron mostrar los testimonios');
+		handleError(data, 'No se pudieron mostrar los testimonios');
 
 		return data;
 	} catch (error) {
@@ -26,7 +26,7 @@ export async function createTestimonial(contactData) {
 			contactData
 		);
 
-		handlError(data, 'Lo sentimos, no fue posible cargar los testimonios');
+		handleError(data, 'Lo sentimos, no fue posible cargar los testimonios');
 
 		return data;
 	} catch (err) {
@@ -41,7 +41,7 @@ export async function getTestimonialById(id) {
 			id
 		);
 
-		handlError(data, 'Lo sentimos, no fue posible mostrar los resultados');
+		handleError(data, 'Lo sentimos, no fue posible mostrar los resultados');
 
 		return data;
 	} catch (error) {
@@ -55,7 +55,7 @@ export async function updateTestimonial(id, contactData) {
 			contactData
 		);
 
-		handlError(data, 'Lo sentimos, no fue posible actualizar los testimonios');
+		handleError(data, 'Lo sentimos, no fue posible actualizar los testimonios');
 
 		return data;
 	} catch (error) {
@@ -69,7 +69,7 @@ export async function deleteTestimonial(id) {
 			url: `${process.env.REACT_APP_TESTIMONIAL_END_POINT}/${id}`,
 		});
 
-		handlError(data, 'Lo sentimos, no fue posible eliminar el testimonio');
+		handleError(data, 'Lo sentimos, no fue posible eliminar el testimonio');
 
 		return data;
 	} catch (error) {
@@ -84,7 +84,7 @@ export async function updateAllTestimonial(id, data) {
 			data
 		);
 
-		handlError(data, 'Lo sentimos, no fue posible actualizar los testimonios');
+		handleError(data, 'Lo sentimos, no fue posible actualizar los testimonios');
 
 		return response;
 	} catch (error) {
@@ -95,7 +95,7 @@ export async function updateAllTestimonial(id, data) {
 // esta funcion maneja y muestra el error por si la peticion falla
 // Solo se ejecuta si la condicion interna es verdadera
 
-const handlError = (data, message) => {
+const handleError = (data, message) => {
 	// se utiliza la propiedad "success" que devuelve el back par comprar si la peticion falla
 	if (data.success !== true) {
 		console.log('el Error se muestra Exitosamente');

--- a/src/Services/testimonialService.js
+++ b/src/Services/testimonialService.js
@@ -4,6 +4,7 @@ import getDataMethodPrivate, {
 	privatePatchRequest,
 	privateDeleteRequest,
 	privatePostRequest,
+	privatePutRequest,
 } from './privateApiService';
 export async function getAllTestimonials() {
 	try {
@@ -74,6 +75,21 @@ export async function deleteTestimonial(id) {
 		return data;
 	} catch (error) {
 		return error;
+	}
+}
+
+export async function updateAllTestimonial(id, data) {
+	try {
+		const response = await privatePutRequest(
+			`${process.env.REACT_APP_TESTIMONIAL_END_POINT}/${id}`,
+			data
+		);
+
+		handlError(data, 'Lo sentimos, no fue posible actualizar los testimonios');
+
+		return response;
+	} catch (error) {
+		console.log(error);
 	}
 }
 


### PR DESCRIPTION
Tarea: https://alkemy-labs.atlassian.net/jira/software/c/projects/OT161/boards/234?modal=detail&selectedIssue=OT161-105

**testimonialService.j**

- Se agrega el mensaje de error si la peticion falla
- Se agrega el metodo para la peticion PUT que estaba faltando.

IMPORTATE

Temporalmente el error es manejado dentro de `try` y no el `catch` porque este ultimo no registra el error cuando ocurre.

Si encuentro una forma de que el catch devuelva el error como debe ser, lo arreglare.

Sugerencias/feedback sobre como devolver el error en el catch son bienvenidos xD

